### PR TITLE
Added RPC classes

### DIFF
--- a/src/blackdoor/cqbe/addressing/Address.java
+++ b/src/blackdoor/cqbe/addressing/Address.java
@@ -76,6 +76,7 @@ public class Address implements Serializable {
      */
     public Address(String address) throws AddressException{
     	//Address this = new Address();
+    	this.overlayAddress = getNullOverlay();
     	StringTokenizer tk = new StringTokenizer(address, ":");
     	if(tk.countTokens() != Address.ADDRESS_SIZE)
     		throw new AddressException("String representation of Address is improperly formatted. Wrong number of elements");

--- a/src/blackdoor/cqbe/node/server/RPCHandler.java
+++ b/src/blackdoor/cqbe/node/server/RPCHandler.java
@@ -74,14 +74,14 @@ public class RPCHandler {
 			return;
 		}catch(AddressException a){
 			DBP.printException(a);
-			responseObject = RPCBuilder.RPCResponseFactory(rpc.getInt("id"),false,null, RPCBuilder.JSONRPCError.INVALID_ADDRESS_FORMAT, a.getMessage());
+			responseObject = RPCBuilder.RPCResponseFactory(rpc.getInt("id"),false,null, RPCException.JSONRPCError.INVALID_ADDRESS_FORMAT, a.getMessage());
 		}catch(RPCException e){
 			if(errorData != null)
 				responseObject = RPCBuilder.RPCResponseFactory(rpc.getInt("id"),false,null,e.getRPCError(), errorData);
 			else
 				responseObject = RPCBuilder.RPCResponseFactory(rpc.getInt("id"),false,null,e.getRPCError());
 		}catch(UnknownHostException e){
-			responseObject = RPCBuilder.RPCResponseFactory(rpc.getInt("id"), false, null, RPCBuilder.JSONRPCError.INVALID_ADDRESS_FORMAT);
+			responseObject = RPCBuilder.RPCResponseFactory(rpc.getInt("id"), false, null, RPCException.JSONRPCError.INVALID_ADDRESS_FORMAT);
 			DBP.printException(e);
 		}
 		
@@ -189,7 +189,7 @@ public class RPCHandler {
 			responseObject = RPCBuilder.RPCResponseFactory(rpc.getInt("id"), true, result, null);
 		}catch(JSONException e){
 			errorData = e.getMessage();
-			throw new RPCException(RPCBuilder.JSONRPCError.INVALID_PARAMS);
+			throw new RPCException(RPCException.JSONRPCError.INVALID_PARAMS);
 		}
 		return responseObject;
 	}

--- a/src/blackdoor/cqbe/rpc/LookupRpc.java
+++ b/src/blackdoor/cqbe/rpc/LookupRpc.java
@@ -1,0 +1,18 @@
+package blackdoor.cqbe.rpc;
+
+import org.json.JSONObject;
+
+public class LookupRpc extends Rpc {
+
+	protected LookupRpc() {
+		super(Method.LOOKUP);
+	}
+
+	@Override
+	public JSONObject toJSON() {
+		JSONObject rpc = getRpcOuterShell();
+		rpc.put("params", getRpcParameterShell());
+		return rpc;
+	}
+
+}

--- a/src/blackdoor/cqbe/rpc/PingRpc.java
+++ b/src/blackdoor/cqbe/rpc/PingRpc.java
@@ -1,0 +1,18 @@
+package blackdoor.cqbe.rpc;
+
+import org.json.JSONObject;
+
+public class PingRpc extends Rpc {
+
+	protected PingRpc() {
+		super(Method.PING);
+	}
+
+	@Override
+	public JSONObject toJSON() {
+		JSONObject rpc = getRpcOuterShell();
+		rpc.put("params", getRpcParameterShell());
+		return rpc;
+	}
+
+}

--- a/src/blackdoor/cqbe/rpc/RPCBuilder.java
+++ b/src/blackdoor/cqbe/rpc/RPCBuilder.java
@@ -31,7 +31,7 @@ public class RPCBuilder {
 	
 	private JSONObject getDefaultParams() throws RPCException {
 		if (sourceIP == null || sourcePort == -1 || destinationO == null) {
-			throw new RPCException(JSONRPCError.INVALID_PARAMS);
+			throw new RPCException(RPCException.JSONRPCError.INVALID_PARAMS);
 		}
 		else
 		{
@@ -51,7 +51,7 @@ public class RPCBuilder {
 	 */
 	public JSONObject buildGET() throws RPCException {
 		if (sourceIP == null || sourcePort == -1 || destinationO == null || index == -1) {
-			throw new RPCException(JSONRPCError.INVALID_PARAMS);
+			throw new RPCException(RPCException.JSONRPCError.INVALID_PARAMS);
 		}
 		else{
 			JSONObject rpc = new JSONObject();
@@ -74,7 +74,7 @@ public class RPCBuilder {
 	 */
 	public JSONObject buildPUT() throws RPCException  {
 		if (sourceIP == null || sourcePort == -1 || destinationO == null || value == null) {
-			throw new RPCException(JSONRPCError.INVALID_PARAMS);
+			throw new RPCException(RPCException.JSONRPCError.INVALID_PARAMS);
 		}
 		else{
 			JSONObject rpc = new JSONObject();
@@ -97,7 +97,7 @@ public class RPCBuilder {
 	 */
 	public JSONObject buildLOOKUP() throws RPCException  {
 		if (sourceIP == null || sourcePort == -1 || destinationO == null) {
-			throw new RPCException(JSONRPCError.INVALID_PARAMS);
+			throw new RPCException(RPCException.JSONRPCError.INVALID_PARAMS);
 		}
 		else
 		{
@@ -112,6 +112,15 @@ public class RPCBuilder {
 			return rpc;
 		}
 	}
+	
+	public LookupRpc buildLookupObject(){
+		if(destinationO == null || sourceIP == null || sourcePort <= 0)
+			throw new RPCException.RPCCreationException("not enough parameters set");
+		LookupRpc ret = new LookupRpc();
+		ret.destination = getDestinationO();
+		ret.source = new L3Address(getSourceIP(), getSourcePort());
+		return ret;
+	}
 
 	/**
 	 * Initializies a PING RPC JSON request to be sent.
@@ -120,7 +129,7 @@ public class RPCBuilder {
 	 */
 	public JSONObject buildPING() throws RPCException {
 		if (sourceIP == null || sourcePort == -1 || destinationO == null) {
-			throw new RPCException(JSONRPCError.INVALID_PARAMS);
+			throw new RPCException(RPCException.JSONRPCError.INVALID_PARAMS);
 		}
 		else{
 			JSONObject rpc = new JSONObject();
@@ -135,6 +144,15 @@ public class RPCBuilder {
 		}
 	}
 	
+	public PingRpc buildPingObject(){
+		if(destinationO == null || sourceIP == null || sourcePort <= 0)
+			throw new RPCException.RPCCreationException("not enough parameters set");
+		PingRpc ret = new PingRpc();
+		ret.destination = getDestinationO();
+		ret.source = new L3Address(getSourceIP(), getSourcePort());
+		return ret;
+	}
+	
 	/**
 	 * Initiliazes a SHUTDOWN RPC JSON request to be sent
 	 *
@@ -142,7 +160,7 @@ public class RPCBuilder {
 	 */
 	public JSONObject buildSHUTDOWN() throws RPCException {
 		if (sourceIP == null || sourcePort == -1 || destinationO == null) {
-			throw new RPCException(JSONRPCError.INVALID_PARAMS);
+			throw new RPCException(RPCException.JSONRPCError.INVALID_PARAMS);
 		}
 		else{
 			JSONObject rpc = new JSONObject();
@@ -211,58 +229,6 @@ public class RPCBuilder {
 	}
 
 	/**
-	 * An enumeration of all the possible JSON RPC error objects supported by this system.
-	 * Contains both the error code and the error message associated with that code.
-	 */
-	public static enum JSONRPCError{
-
-		/**
-		 * Invalid JSON was received by the server.
-		 * An error occurred on the server while parsing the JSON text.
-		 */
-		PARSE_ERROR(-32700, "Parse error"),
-		/**
-		 * The JSON sent is not a valid Request object.
-		 */
-		INVALID_REQUEST(-32600, "Invalid Request"),
-		/**
-		 * The method does not exist / is not available.
-		 */
-		METHOD_NOT_FOUND(-32601,"Method not found"),
-		/**
-		 * Invalid method parameter(s).
-		 */
-		INVALID_PARAMS(-32602,"Invalid params"),
-		/**
-		 * Internal JSON-RPC error.
-		 */
-		INTERNAL_ERROR(-32603, "Internal error"),
-		/**
-		 * When logic goes AWOL, things are worse than SNAFU, and life is FUBAR.
-		 */
-		NODE_SHAT(-32099,"Node has shat itself"),
-		INVALID_ADDRESS_FORMAT(-32001, "Invalid Address Format");
-
-		private final int code;
-		private final String message;
-
-		JSONRPCError(int code, String message){
-			this.code = code;
-			this.message = message;
-		}
-
-		public int getCode(){
-			return code;
-		}
-
-		public String getMessage(){
-			return message;
-		}
-
-
-	}
-
-	/**
 	 * A factory for JSON RPC responses. Creates both successful and unsuccessful responses.
 	 * If successful then error and errorData are irrelevant. else error and errorData are considered and result is irrelevant.
 	 * @param id the id of the JSON RPC request object for which this response is being created. If the error was a parse error or the request was a notification then id should be null.
@@ -272,7 +238,7 @@ public class RPCBuilder {
 	 * @param errorData ignored if successful
 	 * @return a JSON RPC response object
 	 */
-	public static JSONObject RPCResponseFactory(Integer id, boolean successful, Object result, JSONRPCError error, Object errorData ){
+	public static JSONObject RPCResponseFactory(Integer id, boolean successful, Object result, RPCException.JSONRPCError error, Object errorData ){
 		JSONObject response = new JSONObject();
 		response.put("jsonrpc", "2.0");
 		if(id == null){
@@ -304,7 +270,7 @@ public class RPCBuilder {
 	 * @param error
 	 * @return
 	 */
-	public static JSONObject RPCResponseFactory(Integer id, boolean successful, Object result, JSONRPCError error){
+	public static JSONObject RPCResponseFactory(Integer id, boolean successful, Object result, RPCException.JSONRPCError error){
 		return RPCResponseFactory(id, successful, result, error, null);
 	}
 }

--- a/src/blackdoor/cqbe/rpc/RPCException.java
+++ b/src/blackdoor/cqbe/rpc/RPCException.java
@@ -1,10 +1,10 @@
 package blackdoor.cqbe.rpc;
 public class RPCException extends Exception {
-	RPCBuilder.JSONRPCError e;
-	public RPCException(RPCBuilder.JSONRPCError e){
+	RPCException.JSONRPCError e;
+	public RPCException(RPCException.JSONRPCError e){
 		this.e = e;
 	}
-	public RPCBuilder.JSONRPCError getRPCError(){
+	public RPCException.JSONRPCError getRPCError(){
 		return e;
 	}
 
@@ -12,6 +12,58 @@ public class RPCException extends Exception {
 		public RPCCreationException(String message){
 			super(message);
 		}
+	}
+
+	/**
+	 * An enumeration of all the possible JSON RPC error objects supported by this system.
+	 * Contains both the error code and the error message associated with that code.
+	 */
+	public static enum JSONRPCError{
+	
+		/**
+		 * Invalid JSON was received by the server.
+		 * An error occurred on the server while parsing the JSON text.
+		 */
+		PARSE_ERROR(-32700, "Parse error"),
+		/**
+		 * The JSON sent is not a valid Request object.
+		 */
+		INVALID_REQUEST(-32600, "Invalid Request"),
+		/**
+		 * The method does not exist / is not available.
+		 */
+		METHOD_NOT_FOUND(-32601,"Method not found"),
+		/**
+		 * Invalid method parameter(s).
+		 */
+		INVALID_PARAMS(-32602,"Invalid params"),
+		/**
+		 * Internal JSON-RPC error.
+		 */
+		INTERNAL_ERROR(-32603, "Internal error"),
+		/**
+		 * When logic goes AWOL, things are worse than SNAFU, and life is FUBAR.
+		 */
+		NODE_SHAT(-32099,"Node has shat itself"),
+		INVALID_ADDRESS_FORMAT(-32001, "Invalid Address Format");
+	
+		private final int code;
+		private final String message;
+	
+		JSONRPCError(int code, String message){
+			this.code = code;
+			this.message = message;
+		}
+	
+		public int getCode(){
+			return code;
+		}
+	
+		public String getMessage(){
+			return message;
+		}
+	
+	
 	}
 
 }

--- a/src/blackdoor/cqbe/rpc/RPCValidator.java
+++ b/src/blackdoor/cqbe/rpc/RPCValidator.java
@@ -13,7 +13,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import blackdoor.cqbe.node.server.RPCHandler;
-import blackdoor.cqbe.rpc.RPCBuilder.JSONRPCError;
+import blackdoor.cqbe.rpc.RPCException.JSONRPCError;
 
 /**
  * 
@@ -60,17 +60,17 @@ public class RPCValidator {
 		JSONObject error = null;
 		Integer _id = id == -1 ? null : id;
 		if (errorStyle.equals("parse")) 
-			error = RPCBuilder.RPCResponseFactory(_id, false, null, RPCBuilder.JSONRPCError.PARSE_ERROR);
+			error = RPCBuilder.RPCResponseFactory(_id, false, null, RPCException.JSONRPCError.PARSE_ERROR);
 		if (errorStyle.equals("invalid")) 
-			error = RPCBuilder.RPCResponseFactory(_id, false, null, JSONRPCError.INVALID_REQUEST);
+			error = RPCBuilder.RPCResponseFactory(_id, false, null, RPCException.JSONRPCError.INVALID_REQUEST);
 		if (errorStyle.equals("method")) 
-			error = RPCBuilder.RPCResponseFactory(_id, false, null, JSONRPCError.METHOD_NOT_FOUND);
+			error = RPCBuilder.RPCResponseFactory(_id, false, null, RPCException.JSONRPCError.METHOD_NOT_FOUND);
 		if (errorStyle.equals("params"))
-			error = RPCBuilder.RPCResponseFactory(_id, false, null, JSONRPCError.INVALID_PARAMS);
+			error = RPCBuilder.RPCResponseFactory(_id, false, null, RPCException.JSONRPCError.INVALID_PARAMS);
 		if (errorStyle.equals("internal")) 
-			error = RPCBuilder.RPCResponseFactory(_id, false, null, JSONRPCError.INTERNAL_ERROR);
+			error = RPCBuilder.RPCResponseFactory(_id, false, null, RPCException.JSONRPCError.INTERNAL_ERROR);
 		if (error == null)
-			error = RPCBuilder.RPCResponseFactory(_id, false, null, JSONRPCError.NODE_SHAT);
+			error = RPCBuilder.RPCResponseFactory(_id, false, null, RPCException.JSONRPCError.NODE_SHAT);
 		return error;
 	}
 

--- a/src/blackdoor/cqbe/rpc/Rpc.java
+++ b/src/blackdoor/cqbe/rpc/Rpc.java
@@ -1,0 +1,128 @@
+package blackdoor.cqbe.rpc;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Random;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import blackdoor.cqbe.addressing.*;
+import blackdoor.cqbe.rpc.RPCException.JSONRPCError;
+
+/**
+* Created by nfischer3 on 1/22/15.
+*/
+public abstract class Rpc {
+	
+   public static Rpc fromJsonString(String jsonText) throws RPCException{// UnknownHostException, JSONException, AddressException{
+	   //TODO validate string
+	   JSONObject rpcJson;
+	   try{
+		   rpcJson = new JSONObject(jsonText);
+	   }catch(JSONException e){
+		   throw new RPCException(JSONRPCError.PARSE_ERROR);
+	   }
+	   Rpc rpcObject = null;
+	   try{
+		   switch(rpcJson.getString("method")){
+		   case "PUT":
+			   break;
+		   case "SHUTDOWN":
+			   break;
+		   case "GET":
+			   break;
+		   case "PING":
+			   rpcObject = new PingRpc();
+			   rpcObject.method = Method.PING;
+			   break;
+		   case "LOOKUP":
+			   rpcObject = new LookupRpc();
+			   rpcObject.method = Method.LOOKUP;
+			   break;
+		   
+		   default:
+			   throw new RPCException(JSONRPCError.METHOD_NOT_FOUND);
+		   }
+	   }catch(JSONException jsE){
+		   throw new RPCException(JSONRPCError.INVALID_REQUEST);
+	   }
+	   
+	   populateCommonFields(rpcObject, rpcJson);
+	   
+	   return rpcObject;
+   }
+   
+   private static void populateCommonFields(Rpc rpcObject, JSONObject rpcJson) throws RPCException{
+	   try{
+		   JSONObject params = rpcJson.getJSONObject("params");
+		   rpcObject.source = new L3Address(InetAddress.getByName(params.getString("sourceIP")), params.getInt("sourcePort"));
+		   rpcObject.destination = new Address(params.getString("destinationO"));
+	   }catch(UnknownHostException | AddressException addressE){
+		   throw new RPCException(JSONRPCError.INVALID_ADDRESS_FORMAT);
+	   }catch(JSONException jsE){
+		   throw new RPCException(JSONRPCError.INVALID_PARAMS);
+	   }
+	   
+	   try{
+		   rpcObject.id = rpcJson.getInt("id");
+	   }catch(JSONException e){
+		   throw new RPCException(JSONRPCError.INVALID_REQUEST);
+	   }
+   }
+
+   protected Method method;
+   protected L3Address source;
+   protected Address destination;
+   protected int id;
+   
+   protected Rpc(Method method){
+	   this.method = method;
+	   id = new Random().nextInt();
+   }
+
+   public Method getMethod() {
+       return method;
+   }
+
+   public L3Address getSource() {
+       return source;
+   }
+
+   public Address getDestination() {
+       return destination;
+   }
+
+   public int getId() {
+       return id;
+   }
+
+   protected JSONObject getRpcOuterShell(){
+	   JSONObject shell = new JSONObject();
+	   shell.put("jsonrpc", "2.0");
+	   shell.put("method", getMethod().toString());
+	   shell.put("id", new Random().nextInt(Integer.MAX_VALUE));
+	   return shell;
+   }
+   
+   protected JSONObject getRpcParameterShell(){
+	   JSONObject shell = new JSONObject();
+	   //shell.put("sourceO", getSource().overlayAddressToString());
+	   shell.put("sourceIP", getSource().getLayer3Address().getHostName());
+	   shell.put("sourcePort", getSource().getPort());
+	   shell.put("destinationO", getDestination().overlayAddressToString());
+	   return shell;
+   }
+   
+   public abstract JSONObject toJSON();
+   
+   public String toJSONString(){
+	   return toJSON().toString();
+   }
+
+   public static enum Method{
+       GET, PUT, LOOKUP, PING, SHUTDOWN
+   }
+}
+
+

--- a/src/blackdoor/cqbe/test/RPCTester.java
+++ b/src/blackdoor/cqbe/test/RPCTester.java
@@ -85,7 +85,7 @@ public class RPCTester {
     public static void testResponseBuilder(){
         JSONObject goodResponse = RPCBuilder.RPCResponseFactory(5, true, "good one", null);
         System.out.println(goodResponse.toString(2));
-        RPCBuilder.JSONRPCError e = RPCBuilder.JSONRPCError.NODE_SHAT;
+        RPCException.JSONRPCError e = RPCException.JSONRPCError.NODE_SHAT;
         JSONObject errorResponse = RPCBuilder.RPCResponseFactory(null, false, null, e, "poop");
         System.out.println(errorResponse.toString(2));
     }

--- a/src/blackdoor/cqbe/test/RpcTest.java
+++ b/src/blackdoor/cqbe/test/RpcTest.java
@@ -1,0 +1,64 @@
+package blackdoor.cqbe.test;
+
+import static org.junit.Assert.*;
+
+import java.net.InetAddress;
+
+import org.junit.Test;
+
+import blackdoor.cqbe.addressing.Address;
+import blackdoor.cqbe.addressing.L3Address;
+import blackdoor.cqbe.rpc.*;
+
+public class RpcTest {
+	
+	
+
+	@Test
+	public void testFromJsonString() throws RPCException {
+		RPCBuilder builder = new RPCBuilder();
+		builder.setDestinationO(Address.getFullAddress());
+		builder.setSourceIP(InetAddress.getLoopbackAddress());
+		builder.setSourcePort(1234);
+		//test lookup
+		LookupRpc lookupRpc = (LookupRpc) Rpc.fromJsonString(builder.buildLookupObject().toJSONString());
+		assertTrue(lookupRpc.getDestination().equals(Address.getFullAddress()));
+		assertTrue(lookupRpc.getSource().equals(new L3Address(InetAddress.getLoopbackAddress(), 1234)));
+		//test ping
+		PingRpc pingRpc = (PingRpc) Rpc.fromJsonString(builder.buildPingObject().toJSONString());
+		assertTrue(pingRpc.getDestination().equals(Address.getFullAddress()));
+		assertTrue(pingRpc.getSource().equals(new L3Address(InetAddress.getLoopbackAddress(), 1234)));
+	}
+	
+	@Test
+	public void testRPCBuilder(){
+		RPCBuilder builder = new RPCBuilder();
+		builder.setDestinationO(Address.getFullAddress());
+		builder.setSourceIP(InetAddress.getLoopbackAddress());
+		builder.setSourcePort(1234);
+		//test lookup
+		LookupRpc lookupRpc = builder.buildLookupObject();
+		assertTrue(lookupRpc.getDestination().equals(Address.getFullAddress()));
+		assertTrue(lookupRpc.getSource().equals(new L3Address(InetAddress.getLoopbackAddress(), 1234)));
+		//test ping
+		PingRpc pingRpc = builder.buildPingObject();
+		assertTrue(pingRpc.getDestination().equals(Address.getFullAddress()));
+		assertTrue(pingRpc.getSource().equals(new L3Address(InetAddress.getLoopbackAddress(), 1234)));
+	}
+
+	@Test
+	public void testToJSONString() {
+		RPCBuilder builder = new RPCBuilder();
+		builder.setDestinationO(Address.getFullAddress());
+		builder.setSourceIP(InetAddress.getLoopbackAddress());
+		builder.setSourcePort(1234);
+		//Test Lookup
+		LookupRpc lookupRpc = builder.buildLookupObject();
+		System.out.println(lookupRpc.toJSON().toString(2));
+		
+		//test ping
+		PingRpc pingRpc = builder.buildPingObject();
+		System.out.println(pingRpc.toJSON().toString(2));
+	}
+
+}


### PR DESCRIPTION
RPC superclass can parse json strings into objects
RPC subclasses can be turned into JSONObjects or json strings.
addresses issue https://github.com/blackdoor/DAC/issues/29
RPC subclasses for some calls still need to be made.