### PR TITLE
The bitstring that represents an address can now be any size. Long diges...

### DIFF
--- a/src/blackdoor/cqbe/addressing/AddressTable.java
+++ b/src/blackdoor/cqbe/addressing/AddressTable.java
@@ -48,12 +48,7 @@ public class AddressTable extends ConcurrentSkipListMap<byte[], L3Address> imple
 
 	public Address getReferenceAddress(){
 		Address.OverlayComparator c = (Address.OverlayComparator) comparator();
-		try {
-			return new Address(c.getReferenceAddress());
-		} catch (AddressException e) {
-			e.printStackTrace();
-		}
-		throw new RuntimeException();
+		return new Address(c.getReferenceAddress());
 	}
 	
 	/**

--- a/src/blackdoor/cqbe/addressing/CASFileAddress.java
+++ b/src/blackdoor/cqbe/addressing/CASFileAddress.java
@@ -16,7 +16,7 @@ public class CASFileAddress extends FileAddress {
 	
 	public CASFileAddress(File f) throws IOException {
 		super.f = f;
-		overlayAddress = Hash.getFileHash(f);
+		setOverlayAddress(Hash.getFileHash(f));
 	}
 	
 	/**
@@ -29,7 +29,7 @@ public class CASFileAddress extends FileAddress {
 	public CASFileAddress(File f, byte[] bin) throws IOException{
 		Files.write(f.toPath(), bin, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
 		super.f = f;
-		overlayAddress = Hash.getFileHash(f);
+		setOverlayAddress(Hash.getFileHash(f));
 	}
 	
 	/**

--- a/src/blackdoor/cqbe/addressing/L3Address.java
+++ b/src/blackdoor/cqbe/addressing/L3Address.java
@@ -125,7 +125,7 @@ public class L3Address extends Address implements Serializable{
 		byte[] overlay = new byte[l3Bytes.length + portBytes.length];
 		System.arraycopy(l3Bytes, 0, overlay, 0, l3Bytes.length);
 		System.arraycopy(portBytes, 0, overlay, l3Bytes.length, portBytes.length);
-		overlayAddress = Hash.getSHA256(overlay, true);
+		setOverlayAddress(Hash.getSHA256(overlay, true));
 	}
 
 	/**
@@ -165,7 +165,7 @@ public class L3Address extends Address implements Serializable{
 		if (getClass() != obj.getClass())
 			return false;
 		L3Address other = (L3Address) obj;
-		if (!Arrays.equals(overlayAddress, other.overlayAddress))
+		if (!Arrays.equals(getShallowOverlayAddress(), other.getShallowOverlayAddress()))
 			return false;
 		return true;
 	}

--- a/src/blackdoor/cqbe/node/Node.java
+++ b/src/blackdoor/cqbe/node/Node.java
@@ -73,14 +73,8 @@ public class Node {
 		OverlayComparator c = (OverlayComparator) getInstance().addressTable
 				.comparator();
 
-		try {
-			return new Address(c.getReferenceAddress());
-		} catch (AddressException e) {
-			DBP.printerrorln("The address in the OverlayComparator is not valid for building a new Address object");
-			DBP.printerrorln("THIS IS BAAAAADDDD GO TO GITHUB AND OPEN AN ISSUE NOOWWW!!!");
-			DBP.printException(e);
-		}
-		return null;
+		return new Address(c.getReferenceAddress());
+
 	}
 
 	protected Node() {

--- a/test/blackdoor/cqbe/addressing/AddressTest.java
+++ b/test/blackdoor/cqbe/addressing/AddressTest.java
@@ -1,0 +1,50 @@
+package blackdoor.cqbe.addressing;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import blackdoor.util.Misc;
+
+public class AddressTest {
+	
+	byte[] array;
+
+	@Before
+	public void setUp() throws Exception {
+		array = new byte[32];
+		for(int i = 0; i < array.length; i++){
+			array[i] = (byte) i;
+		}
+	}
+
+	@Test
+	public void testAddressByteArray() {
+		assertArrayEquals(new Address(array).getShallowOverlayAddress(), Arrays.copyOf(array, Address.DEFAULT_ADDRESS_SIZE));
+	}
+
+	@Test
+	public void testGetNullAddress() {
+		System.out.println(Address.getNullAddress());
+		assertTrue(Address.getNullAddress().getShallowOverlayAddress().length == Address.DEFAULT_ADDRESS_SIZE);
+	}
+
+	@Test
+	public void testAddressString() throws AddressException {
+		assertEquals(new Address(array), new Address(new Address(array).toString()));
+	}
+
+	@Test
+	public void testSetOverlayAddress() {
+		assertArrayEquals(new Address(array).getShallowOverlayAddress(), Arrays.copyOf(array, Address.DEFAULT_ADDRESS_SIZE));
+	}
+
+	@Test
+	public void testOverlayAddressToString() {
+		System.out.println(new Address(array));
+	}
+
+}


### PR DESCRIPTION
The bitstring that represents an address can now be any size. Long digests are truncated by section 7 FIPS 180-4