### PR TITLE
SocketIO happens at AcceptedRPC now

### DIFF
--- a/src/blackdoor/cqbe/node/server/RPCHandler.java
+++ b/src/blackdoor/cqbe/node/server/RPCHandler.java
@@ -45,20 +45,21 @@ import blackdoor.util.DBP;
 public class RPCHandler {
 
 	private JSONObject rpc;
-	private SocketIOWrapper io;
 	private String errorData = null;
+	private SocketIOWrapper io; 
 
-	public RPCHandler(SocketIOWrapper outy, JSONObject rpc) {
+	public RPCHandler(JSONObject rpc, SocketIOWrapper io) {
 		this.rpc = rpc;
-		this.io = outy;
+		this.io = io;
 	}
 
 	/**
 	 * Handles appropriate RPC call
+	 * @return 
 	 * 
 	 * @throws IOException
 	 */
-	public void handle() throws IOException {
+	public JSONObject handle() throws IOException {
 
 		JSONObject responseObject;
 		try {
@@ -79,9 +80,8 @@ public class RPCHandler {
 				break;
 			case SHUTDOWN:
 				handleShutdown();
-				return;
+				return null;
 			default:
-				io.close();
 				throw new RuntimeException(
 						"WTF IS THISSSS??? I'm looking at a method type that I don't recognize! WHERE is the validator? Is it on vacation? Cause it's not validating!");
 			}
@@ -89,7 +89,7 @@ public class RPCHandler {
 			DBP.printException(j);
 			DBP.printerrorln("Apparently the RPC validator is broken");
 			DBP.printerrorln("A JSON-RPC response is not being sent, better fix the validator");
-			return;
+			return null;
 		} catch (AddressException a) {
 			DBP.printException(a);
 			responseObject = RPCBuilder.RPCResponseFactory(rpc.getInt("id"),
@@ -110,16 +110,10 @@ public class RPCHandler {
 					RPCException.JSONRPCError.INVALID_ADDRESS_FORMAT);
 			DBP.printException(e);
 		}
-
-
-		try {
 			// DBP.printdevln("in handle");
 			// DBP.printdevln("about to write response " + responseObject);
 
-			io.write(responseObject.toString());
-		} finally {
-			io.close();
-		}
+		return responseObject;
 	}
 
 	/**

--- a/src/blackdoor/cqbe/rpc/RPCValidator.java
+++ b/src/blackdoor/cqbe/rpc/RPCValidator.java
@@ -27,30 +27,31 @@ public class RPCValidator {
 	private String call;
 	private SocketIOWrapper io;
 
-	public RPCValidator(String rpcCall, SocketIOWrapper oStream) {
+	public RPCValidator(String rpcCall, SocketIOWrapper io) {
 		call = rpcCall;
-		io = oStream;
+		this.io = io;
 	}
 
-	public void handle() {
+	public JSONObject handle() {
 		String validity = isValid(call);
+		JSONObject jo = null;
 		try {
 			if (validity.equals("valid")) {
 				// Handle the call by passing off to the handler.
 				// String methodCalled = call.getString("method");
-				RPCHandler handler = new RPCHandler(io, new JSONObject(call));
-				handler.handle();
+				RPCHandler handler = new RPCHandler(new JSONObject(call), io);
+				jo = handler.handle();
 			} else {
-				JSONObject error = buildError(
+				jo = buildError(
 						validity,
 						validity.equals("parse") ? -1 : new JSONObject(call)
 								.getInt("id"));
-				io.write(error.toString());
 			}
 		} catch (IOException e1) {
 			// TODO Auto-generated catch block
 			DBP.printException(e1);
 		}
+		return jo;
 	}
 
 	public JSONObject buildError(String errorStyle, int id) {


### PR DESCRIPTION
+RPCvalidoator handle returns a jsonobject with the proper response to a query
+Handler returns a jsonobject as well
-shutdown still needs the socketiowrapper, so that is why it is still being passed up the stack

*Passes unit tests*