### PR TITLE
Storage Controller Small AT Fix

### DIFF
--- a/src/blackdoor/cqbe/addressing/Address.java
+++ b/src/blackdoor/cqbe/addressing/Address.java
@@ -6,6 +6,7 @@ import blackdoor.util.Misc;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Comparator;
 import java.util.StringTokenizer;
 
@@ -220,6 +221,13 @@ public class Address implements Serializable {
         }
     }
 
+	public Address getComplement(){
+		BitSet a = new BitSet();
+		a = BitSet.valueOf(this.getOverlayAddress());
+		a.xor(BitSet.valueOf(Address.getFullOverlay()));
+		return new Address(a.toByteArray());
+	}
+	
 	/**
 	 * A comparator for Addresses. Distance between Addresses is defined as the Hamming weight of the first address XOR'd with the second.
 	 * Since two addresses can only have a distance between them a reference point is needed to determine which is greater than the other.

--- a/src/blackdoor/cqbe/storage/StorageController.java
+++ b/src/blackdoor/cqbe/storage/StorageController.java
@@ -104,12 +104,15 @@ public class StorageController implements Map<Address, FileAddress> {
 		return isAutoRemappingEnabled() ? addressTable.getReferenceAddress() : reference;
 	}
 
-	public Address getLowest(){
+	private Address getLowest(){
 		return isAutoRemappingEnabled() && !addressTable.isEmpty() ? addressTable.firstEntry().getValue() : lowest;
 	}
 
-	public Address getHighest(){
-		return isAutoRemappingEnabled() && !addressTable.isEmpty() ? addressTable.lastEntry().getValue() : highest;
+	private Address getHighest(){
+		if(this.addressTable.size() < (this.addressTable.getMaxSize()*.9))
+			return isAutoRemappingEnabled() ? this.getReferenceAddress().getComplement(): highest;
+		else
+			return isAutoRemappingEnabled() ? addressTable.lastEntry().getValue() : highest;
 	}
 	
 	public synchronized void remap(Address nearest, Address farthest){

--- a/test/blackdoor/cqbe/addressing/AddressTest.java
+++ b/test/blackdoor/cqbe/addressing/AddressTest.java
@@ -12,6 +12,7 @@ import blackdoor.util.Misc;
 public class AddressTest {
 	
 	byte[] array;
+	Address a;
 
 	@Before
 	public void setUp() throws Exception {
@@ -19,6 +20,7 @@ public class AddressTest {
 		for(int i = 0; i < array.length; i++){
 			array[i] = (byte) i;
 		}
+		a = new Address(array);
 	}
 
 	@Test
@@ -45,6 +47,12 @@ public class AddressTest {
 	@Test
 	public void testOverlayAddressToString() {
 		System.out.println(new Address(array));
+	}
+	
+	@Test
+	public void testComplementAddress() {
+		System.out.println(a);
+		System.out.println(a.getComplement());
 	}
 
 }


### PR DESCRIPTION
When the AT of a StorageController is below max size, the highest
address is the reference’s complement. This is unobtainably high,
meaning there is no third bucket.